### PR TITLE
Switch to Singbox for proxy monitoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ go.work.sum
 
 # env file
 .env
-xray-checker
-xray_config.json
+singbox-checker
+singbox_config.json
 docker-compose.yml
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Xray Checker
+# Singbox Checker
 
 [![GitHub Release](https://img.shields.io/github/v/release/kutovoys/xray-checker?style=flat&color=blue)](https://github.com/kutovoys/xray-checker/releases/latest)
 [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/kutovoys/xray-checker/build-publish.yml)](https://github.com/kutovoys/xray-checker/actions/workflows/build-publish.yml)
@@ -8,7 +8,7 @@
 [![ru](https://img.shields.io/badge/lang-ru-blue)](https://github.com/kutovoys/xray-checker/blob/main/README_RU.md)
 [![en](https://img.shields.io/badge/lang-en-red)](https://github.com/kutovoys/xray-checker/blob/main/README.md)
 
-Xray Checker is a tool for monitoring proxy server availability with support for VLESS, VMess, Trojan, and Shadowsocks protocols. It automatically tests connections through Xray Core and provides metrics for Prometheus, as well as API endpoints for integration with monitoring systems.
+Singbox Checker is a tool for monitoring proxy server availability with support for VLESS, VMess, Trojan, and Shadowsocks protocols. It automatically tests connections through Singbox and provides metrics for Prometheus, as well as API endpoints for integration with monitoring systems.
 
 <div align="center">
   <img src=".github/screen/xray-checker.png" alt="Dashboard Screenshot">
@@ -16,7 +16,7 @@ Xray Checker is a tool for monitoring proxy server availability with support for
 
 ## 🚀 Key Features
 
-- 🔍 Monitoring of Xray proxy servers (VLESS, VMess, Trojan, Shadowsocks)
+- 🔍 Monitoring of Singbox proxy servers (VLESS, VMess, Trojan, Shadowsocks)
 - 🔄 Automatic configuration updates from subscription
 - 📊 Prometheus metrics export
 - 🌓 Web interface with dark/light theme
@@ -68,7 +68,7 @@ Detailed installation and configuration documentation is available at [xray-chec
 
 ## 🤝 Contributing
 
-We welcome any contributions to Xray Checker! If you want to help:
+We welcome any contributions to Singbox Checker! If you want to help:
 
 1. Fork the repository
 2. Create a branch for your changes
@@ -78,7 +78,7 @@ We welcome any contributions to Xray Checker! If you want to help:
 For more details on how to contribute, read the [contributor's guide](https://xray-checker.kutovoy.dev/contributing/development-guide).
 
 <p align="center">
-Thanks to the all contributors who have helped improve Xray Checker:
+Thanks to the all contributors who have helped improve Singbox Checker:
 </p>
 <p align="center">
 <a href="https://github.com/kutovoys/xray-checker/graphs/contributors">

--- a/README_RU.md
+++ b/README_RU.md
@@ -1,4 +1,4 @@
-# Xray Checker
+# Singbox Checker
 
 [![GitHub Release](https://img.shields.io/github/v/release/kutovoys/xray-checker?style=flat&color=blue)](https://github.com/kutovoys/xray-checker/releases/latest)
 [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/kutovoys/xray-checker/build-publish.yml)](https://github.com/kutovoys/xray-checker/actions/workflows/build-publish.yml)
@@ -8,7 +8,7 @@
 [![ru](https://img.shields.io/badge/lang-ru-blue)](https://github.com/kutovoys/xray-checker/blob/main/README_RU.md)
 [![en](https://img.shields.io/badge/lang-en-red)](https://github.com/kutovoys/xray-checker/blob/main/README.md)
 
-Xray Checker - это инструмент для мониторинга доступности прокси-серверов с поддержкой протоколов VLESS, VMess, Trojan и Shadowsocks. Он автоматически тестирует соединения через Xray Core и предоставляет метрики для Prometheus, а также API-эндпоинты для интеграции с системами мониторинга.
+Singbox Checker - это инструмент для мониторинга доступности прокси-серверов с поддержкой протоколов VLESS, VMess, Trojan и Shadowsocks. Он автоматически тестирует соединения через Singbox и предоставляет метрики для Prometheus, а также API-эндпоинты для интеграции с системами мониторинга.
 
 <div align="center">
   <img src=".github/screen/xray-checker.png" alt="Dashboard Screenshot">
@@ -68,7 +68,7 @@ services:
 
 ## 🤝 Участие в разработке
 
-Мы рады любому вкладу в развитие Xray Checker! Если вы хотите помочь:
+Мы рады любому вкладу в развитие Singbox Checker! Если вы хотите помочь:
 
 1. Сделайте форк репозитория
 2. Создайте ветку для ваших изменений
@@ -78,7 +78,7 @@ services:
 Подробнее о том, как внести свой вклад, читайте в [руководстве для контрибьюторов](https://xray-checker.kutovoy.dev/ru/contributing/development-guide).
 
 <p align="center">
-Спасибо всем контрибьюторам, которые помогли улучшить Xray Checker:
+Спасибо всем контрибьюторам, которые помогли улучшить Singbox Checker:
 </p>
 <p align="center">
 <a href="https://github.com/kutovoys/xray-checker/graphs/contributors">

--- a/config/config.go
+++ b/config/config.go
@@ -10,8 +10,8 @@ var CLIConfig CLI
 
 func Parse(version string) {
 	ctx := kong.Parse(&CLIConfig,
-		kong.Name("xray-checker"),
-		kong.Description("Xray Checker: A Prometheus exporter for monitoring Xray proxies"),
+		kong.Name("singbox-checker"),
+		kong.Description("Singbox Checker: A Prometheus exporter for monitoring Singbox proxies"),
 		kong.Vars{
 			"version": version,
 		},
@@ -35,9 +35,9 @@ type CLI struct {
 		SimulateLatency bool   `name:"simulate-latency" help:"Whether to add latency to the response" default:"true" env:"SIMULATE_LATENCY"`
 	} `embed:"" prefix:""`
 
-	Xray struct {
-		StartPort int    `name:"xray-start-port" help:"Start port for proxy configuration" default:"10000" env:"XRAY_START_PORT"`
-		LogLevel  string `name:"xray-log-level" help:"Xray log level (debug|info|warning|error|none)" default:"none" env:"XRAY_LOG_LEVEL"`
+	Singbox struct {
+		StartPort int    `name:"singbox-start-port" help:"Start port for proxy configuration" default:"10000" env:"SINGBOX_START_PORT"`
+		LogLevel  string `name:"singbox-log-level" help:"Singbox log level (debug|info|warning|error|none)" default:"none" env:"SINGBOX_LOG_LEVEL"`
 	} `embed:"" prefix:""`
 
 	Metrics struct {
@@ -48,7 +48,7 @@ type CLI struct {
 		Password  string `name:"metrics-password" help:"Password for metrics if protected by basic auth" default:"MetricsVeryHardPassword" env:"METRICS_PASSWORD"`
 		Instance  string `name:"metrics-instance" help:"Instance label for metrics" default:"" env:"METRICS_INSTANCE"`
 		PushURL   string `name:"metrics-push-url" help:"Prometheus pushgateway URL (e.g. https://user:pass@host:port)" default:"" env:"METRICS_PUSH_URL"`
-		BasePath  string `name:"metrics-base-path" help:"URL path to metrics (e.g. /xray/metrics)" default:"" env:"METRICS_BASE_PATH"`
+		BasePath  string `name:"metrics-base-path" help:"URL path to metrics (e.g. /singbox/metrics)" default:"" env:"METRICS_BASE_PATH"`
 	} `embed:"" prefix:""`
 
 	Version VersionFlag `name:"version" help:"Print version information and quit"`
@@ -60,9 +60,9 @@ type VersionFlag string
 func (v VersionFlag) Decode(ctx *kong.DecodeContext) error { return nil }
 func (v VersionFlag) IsBool() bool                         { return true }
 func (v VersionFlag) BeforeApply(app *kong.Kong, vars kong.Vars) error {
-	fmt.Println("Xray Checker: A Prometheus exporter for monitoring Xray proxies")
+	fmt.Println("Singbox Checker: A Prometheus exporter for monitoring Singbox proxies")
 	fmt.Printf("Version:\t %s\n", vars["version"])
-	fmt.Printf("GitHub: https://github.com/kutovoys/xray-checker\n")
+	fmt.Printf("GitHub: https://github.com/kutovoys/singbox-checker\n")
 	app.Exit(0)
 	return nil
 }

--- a/runner/singbox.go
+++ b/runner/singbox.go
@@ -1,0 +1,51 @@
+package runner
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+)
+
+type SingboxRunner struct {
+	cmd        *exec.Cmd
+	configFile string
+}
+
+func NewSingboxRunner(configFile string) *SingboxRunner {
+	return &SingboxRunner{configFile: configFile}
+}
+
+func (r *SingboxRunner) Start() error {
+	r.cmd = exec.Command("sing-box", "run", "-c", r.configFile)
+	r.cmd.Stdout = os.Stdout
+	r.cmd.Stderr = os.Stderr
+
+	if err := r.cmd.Start(); err != nil {
+		return fmt.Errorf("error starting sing-box: %v", err)
+	}
+
+	go func() {
+		_ = r.cmd.Wait()
+		r.cmd = nil
+	}()
+
+	log.Println("sing-box started successfully")
+	return nil
+}
+
+func (r *SingboxRunner) Stop() error {
+	if r.cmd != nil && r.cmd.Process != nil {
+		if err := r.cmd.Process.Signal(os.Interrupt); err != nil {
+			return fmt.Errorf("error stopping sing-box: %v", err)
+		}
+		_, _ = r.cmd.Process.Wait()
+		r.cmd = nil
+		log.Println("sing-box stopped successfully")
+	}
+	return nil
+}
+
+func (r *SingboxRunner) IsRunning() bool {
+	return r.cmd != nil && r.cmd.ProcessState == nil
+}

--- a/singbox/template.go
+++ b/singbox/template.go
@@ -1,0 +1,6 @@
+package singbox
+
+import "embed"
+
+//go:embed templates/singbox.json.tmpl
+var templates embed.FS

--- a/singbox/templates/singbox.json.tmpl
+++ b/singbox/templates/singbox.json.tmpl
@@ -1,7 +1,7 @@
 {{/* Base template structure */}}
 {
   "log": {
-    "loglevel": "{{.XrayLogLevel}}"
+    "loglevel": "{{.LogLevel}}"
   },
   "inbounds": [
     {{- range $index, $proxy := .Proxies }}

--- a/subscription/subscription.go
+++ b/subscription/subscription.go
@@ -14,8 +14,8 @@ import (
 	"xray-checker/config"
 	"xray-checker/models"
 	"xray-checker/parser"
+	singbox "xray-checker/singbox"
 	"xray-checker/utils"
-	"xray-checker/xray"
 )
 
 func InitializeConfiguration(configFile string) (*[]*models.ProxyConfig, error) {
@@ -25,9 +25,9 @@ func InitializeConfiguration(configFile string) (*[]*models.ProxyConfig, error) 
 	}
 	proxyConfigs := &configs
 
-	xray.PrepareProxyConfigs(*proxyConfigs)
-	if err := xray.GenerateAndSaveConfig(*proxyConfigs, config.CLIConfig.Xray.StartPort, configFile, config.CLIConfig.Xray.LogLevel); err != nil {
-		return nil, fmt.Errorf("error generating Xray config: %v", err)
+	singbox.PrepareProxyConfigs(*proxyConfigs)
+	if err := singbox.GenerateAndSaveConfig(*proxyConfigs, config.CLIConfig.Singbox.StartPort, configFile, config.CLIConfig.Singbox.LogLevel); err != nil {
+		return nil, fmt.Errorf("error generating Singbox config: %v", err)
 	}
 
 	return proxyConfigs, nil

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -28,7 +28,7 @@ func IndexHandler(version string, proxyChecker *checker.ProxyChecker) http.Handl
 			return
 		}
 
-		RegisterConfigEndpoints(proxyChecker.GetProxies(), proxyChecker, config.CLIConfig.Xray.StartPort)
+		RegisterConfigEndpoints(proxyChecker.GetProxies(), proxyChecker, config.CLIConfig.Singbox.StartPort)
 
 		data := PageData{
 			Version:                    version,
@@ -42,7 +42,7 @@ func IndexHandler(version string, proxyChecker *checker.ProxyChecker) http.Handl
 			Timeout:                    config.CLIConfig.Proxy.Timeout,
 			SubscriptionUpdate:         config.CLIConfig.Subscription.Update,
 			SubscriptionUpdateInterval: config.CLIConfig.Subscription.UpdateInterval,
-			StartPort:                  config.CLIConfig.Xray.StartPort,
+			StartPort:                  config.CLIConfig.Singbox.StartPort,
 			Instance:                   config.CLIConfig.Metrics.Instance,
 			PushUrl:                    metrics.GetPushURL(config.CLIConfig.Metrics.PushURL),
 			Endpoints:                  registeredEndpoints,

--- a/xray/template.go
+++ b/xray/template.go
@@ -1,6 +1,0 @@
-package xray
-
-import "embed"
-
-//go:embed templates/xray.json.tmpl
-var templates embed.FS


### PR DESCRIPTION
## Summary
- add `SingboxRunner` to manage sing-box process
- rename configuration options and defaults from Xray to Singbox
- update main program to start Singbox and generate `singbox_config.json`
- move Xray helper package to `singbox` and adjust template
- update documentation to reference Singbox

## Testing
- `go vet ./...` *(fails: Get https://proxy.golang.org/... Forbidden)*
- `go test ./...` *(fails: Get https://proxy.golang.org/... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685d51a88ef08323a74c6997d6006bec